### PR TITLE
UDCSL #116 - Videos/PDFs

### DIFF
--- a/app/models/concerns/attachable.rb
+++ b/app/models/concerns/attachable.rb
@@ -90,6 +90,13 @@ module Attachable
         attachment.url(disposition: 'attachment')
       end
 
+      define_method("#{name}_inline_url") do
+        attachment = self.send(name)
+        return nil unless attachment.attached?
+
+        attachment.url(disposition: 'inline')
+      end
+
       define_method("#{name}_preview_url") do
         attachment = self.send(name)
         return nil unless attachment.attached?

--- a/app/serializers/resources_serializer.rb
+++ b/app/serializers/resources_serializer.rb
@@ -3,7 +3,7 @@ class ResourcesSerializer < BaseSerializer
   include UserDefinedFields::FieldableSerializer
 
   index_attributes :id, :uuid, :name, :exif, :project_id, :content_url, :content_thumbnail_url, :content_iiif_url,
-                   :content_preview_url, :content_download_url, :manifest, :content_type
+                   :content_preview_url, :content_download_url, :content_inline_url, :manifest, :content_type
   show_attributes :id, :uuid, :name, :exif, :project_id, :content_url, :content_thumbnail_url, :content_iiif_url,
-                  :content_preview_url, :content_download_url, :manifest, :content_type
+                  :content_preview_url, :content_download_url, :content_inline_url, :manifest, :content_type
 end


### PR DESCRIPTION
This pull request adds the `*_inline_url` to the `attachable concern and adds the `content_inline_url` attribute to the `resources_serializer` to be sent on the payload. This is necessary in order to generate a URL that allows a PDF to be opened in a new tab/window.