### PR TITLE
Archnet #1183 - PNG Images

### DIFF
--- a/app/services/images/convert.rb
+++ b/app/services/images/convert.rb
@@ -16,6 +16,8 @@ module Images
       convert << '8'
       convert << '-compress'
       convert << 'jpeg'
+      convert << '-alpha'
+      convert << 'remove'
       convert << "ptif:#{output_path}"
       convert.call
 


### PR DESCRIPTION
This pull request updates the image conversion script to remove any alpha channels from the source image when converting to `ptif`. If not removed, the images were being rendered with a white overlay. This pull request also adds the `iiif:convert_images_by_type` rake task to allow converting all images with a specified MIME type.