### PR TITLE
Archnet #1216 - Image Colors

### DIFF
--- a/Aptfile
+++ b/Aptfile
@@ -1,2 +1,2 @@
 # Dependencies
-imagemagick=7.1.1-34
+imagemagick=7.1.1

--- a/Aptfile
+++ b/Aptfile
@@ -1,0 +1,2 @@
+# Dependencies
+imagemagick=7.1.1-34

--- a/Aptfile
+++ b/Aptfile
@@ -1,2 +1,0 @@
-# Dependencies
-imagemagick=7.1.1

--- a/Gemfile
+++ b/Gemfile
@@ -39,9 +39,6 @@ gem 'aws-sdk-s3'
 # Image processing
 gem 'mini_magick', '~> 4.11'
 
-# EXIF data
-gem 'exif', '~> 2.2.3'
-
 # HTTP requests
 gem 'httparty', '~> 0.17.3'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -119,7 +119,6 @@ GEM
       dotenv (= 2.7.6)
       railties (>= 3.2)
     erubi (1.10.0)
-    exif (2.2.3)
     globalid (1.0.0)
       activesupport (>= 5.0)
     httparty (0.17.3)
@@ -234,7 +233,6 @@ DEPENDENCIES
   data_migrate (~> 8.1.1)
   debug
   dotenv-rails
-  exif (~> 2.2.3)
   httparty (~> 0.17.3)
   jwt
   mini_magick (~> 4.11)

--- a/app/jobs/extract_exif_job.rb
+++ b/app/jobs/extract_exif_job.rb
@@ -1,14 +1,21 @@
 class ExtractExifJob < ApplicationJob
+
   def perform(resource_id)
     resource = Resource.find(resource_id)
     return unless resource.content.image?
 
-    resource.content.open do |file|
-      data = Images::Exif.extract(file)
+    exif = nil
 
-      if data.present?
-        resource.update(exif: JSON.dump(data))
+    begin
+      resource.content.open do |file|
+        image_data = MiniMagick::Image.open(file.path)
+        exif = JSON.dump(image_data.data) if image_data&.data.present?
       end
+    rescue StandardError => e
+      Rails.logger.error e.message
+      Rails.logger.error e.backtrace.join("\n")
     end
+
+    resource.update(exif: exif)
   end
 end


### PR DESCRIPTION
This pull request removes the `exif` gem and updates the `extract_exif_job` to use `mini-magick` to pull image information. Currently the image information is used for display purposes only, so changing the format should not impact anything.