### PR TITLE
Archnet #1216 - Image colors

### DIFF
--- a/app/services/images/convert.rb
+++ b/app/services/images/convert.rb
@@ -18,6 +18,8 @@ module Images
       convert << 'jpeg'
       convert << '-alpha'
       convert << 'remove'
+      convert << '-colorspace'
+      convert << 'sRGB'
       convert << "ptif:#{output_path}"
       convert.call
 


### PR DESCRIPTION
This pull request updates the `convert` service to always use the "RGB" colorspace. It also adds the `convert_images_by_colorspace` rake task.