### PR TITLE
Archnet #1314 - IIIF Images

### DIFF
--- a/app/controllers/public/resources_controller.rb
+++ b/app/controllers/public/resources_controller.rb
@@ -6,7 +6,7 @@ class Public::ResourcesController < Api::ResourcesController
   prepend_before_action :set_project_id, only: :index
   prepend_before_action :set_resource_id, only: [:show, :destroy, :update]
   prepend_before_action :set_resource_project_id, only: [:create, :update]
-  skip_before_action :authenticate_request, only: [:content, :download, :iiif, :inline, :manifest, :preview, :thumbnail]
+  skip_before_action :authenticate_request, only: [:content, :download, :iiif, :info, :inline, :manifest, :preview, :thumbnail]
 
   def content
     redirect_resource :content_url
@@ -17,7 +17,11 @@ class Public::ResourcesController < Api::ResourcesController
   end
 
   def iiif
-    redirect_resource :content_iiif_url
+    redirect_resource :content_converted_iiif_url
+  end
+
+  def info
+    redirect_resource :content_converted_info_url
   end
 
   def inline
@@ -30,11 +34,11 @@ class Public::ResourcesController < Api::ResourcesController
   end
 
   def preview
-    redirect_resource :content_preview_url
+    redirect_resource :content_converted_preview_url
   end
 
   def thumbnail
-    redirect_resource :content_thumbnail_url
+    redirect_resource :content_converted_thumbnail_url
   end
 
   private

--- a/app/models/concerns/attachable.rb
+++ b/app/models/concerns/attachable.rb
@@ -90,6 +90,15 @@ module Attachable
         attachment.url(disposition: 'attachment')
       end
 
+      define_method("#{name}_info_url") do |page_number = nil|
+        attachment = self.send(name)
+        return nil unless attachment.attached?
+
+        return nil if attachment.audio?
+
+        "#{self.send("#{name}_base_url")}#{page_number.nil? ? '' : ";#{page_number}"}/info.json"
+      end
+
       define_method("#{name}_inline_url") do
         attachment = self.send(name)
         return nil unless attachment.attached?

--- a/app/models/resource.rb
+++ b/app/models/resource.rb
@@ -30,6 +30,7 @@ class Resource < ApplicationRecord
   alias_method :attachable_content_base_url, :content_base_url
   alias_method :attachable_content_preview_url, :content_preview_url
   alias_method :attachable_content_iiif_url, :content_iiif_url
+  alias_method :attachable_content_info_url, :content_info_url
   alias_method :attachable_content_thumbnail_url, :content_thumbnail_url
 
   def self.with_attachment(name)
@@ -53,30 +54,24 @@ class Resource < ApplicationRecord
   end
 
   def content_iiif_url(page_number = 1)
-    # Image files must return the converted TIF URL
-    return content_converted_iiif_url(page_number) if image?
-
-    # Only IIIF resources will return a content_iiif_url
     return attachable_content_iiif_url(page_number) if iiif?
 
     nil
   end
 
-  def content_preview_url
-    # Image files must return the converted TIF URL
-    return content_converted_preview_url if image?
+  def content_info_url(page_number = 1)
+    return attachable_content_info_url(page_number) if iiif?
 
-    # Only IIIF resources will return a content_preview_url
+    nil
+  end
+
+  def content_preview_url
     return attachable_content_preview_url if iiif?
 
     nil
   end
 
   def content_thumbnail_url
-    # Image files must return the converted TIF URL
-    return content_converted_thumbnail_url if image?
-
-    # Only IIIF resources will return a content_thumbnail_url
     return attachable_content_thumbnail_url if iiif?
 
     nil

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,6 +24,7 @@ Rails.application.routes.draw do
         get :content
         get :download
         get :iiif
+        get :info
         get :inline
         get :manifest
         get :preview


### PR DESCRIPTION
This pull request refactors the change in #73 to allow the controller to redirect to the appropriate content URL, rather than the model. This allows applications that use the IIIF Cloud public API directly to still retrieve a value for the `content_iiif_url`, `content_preview_url`, and `content_thumbnail_url` attributes even if there is no converted content.

This pull request also adds the `/resources/:id/info` endpoint to redirect to the `info.json` for the converted content.