### PR TITLE
IIIF #87 - Manifests

### DIFF
--- a/app/controllers/public/resources_controller.rb
+++ b/app/controllers/public/resources_controller.rb
@@ -3,11 +3,11 @@ class Public::ResourcesController < Api::ResourcesController
   include Public::Authenticateable
 
   # Actions
-  prepend_before_action :set_page, only: [:iiif, :info]
+  prepend_before_action :set_page, only: [:iiif, :image_api, :info]
   prepend_before_action :set_project_id, only: :index
   prepend_before_action :set_resource_id, only: [:show, :destroy, :update]
   prepend_before_action :set_resource_project_id, only: [:create, :update]
-  skip_before_action :authenticate_request, only: [:content, :download, :iiif, :info, :inline, :manifest, :preview, :thumbnail]
+  skip_before_action :authenticate_request, only: [:content, :download, :iiif, :image_api, :info, :inline, :manifest, :preview, :thumbnail]
 
   def content
     redirect_resource do |resource|
@@ -26,6 +26,23 @@ class Public::ResourcesController < Api::ResourcesController
 
     redirect_resource do |resource|
       resource.image? ? resource.content_converted_iiif_url(page_number) : resource.content_iiif_url(page_number)
+    end
+  end
+
+  def image_api
+    page_number = params[:page] || 1
+
+    redirect_resource do |resource|
+      if resource.image?
+        resource.content_converted_image_api_url(
+          page_number,
+          params[:region],
+          params[:size],
+          params[:rotation],
+          params[:quality],
+          params[:format]
+        )
+      end
     end
   end
 

--- a/app/models/concerns/attachable.rb
+++ b/app/models/concerns/attachable.rb
@@ -76,6 +76,15 @@ module Attachable
         "#{self.send("#{name}_base_url")}#{page_number.nil? ? '' : ";#{page_number}"}/full/max/0/default.jpg"
       end
 
+      define_method("#{name}_image_api_url") do |page_number = nil, region = 'full', size = 'max', rotation = '0', quality = 'default', format= 'jpg'|
+        attachment = self.send(name)
+        return nil unless attachment.attached?
+
+        return nil if attachment.audio?
+
+        "#{self.send("#{name}_base_url")}#{page_number.nil? ? '' : ";#{page_number}"}/#{region}/#{size}/#{rotation}/#{quality}.#{format}"
+      end
+
       define_method("#{name}_base_url") do
         attachment = self.send(name)
         return nil unless attachment.attached?

--- a/app/models/resource.rb
+++ b/app/models/resource.rb
@@ -30,6 +30,7 @@ class Resource < ApplicationRecord
   alias_method :attachable_content_base_url, :content_base_url
   alias_method :attachable_content_preview_url, :content_preview_url
   alias_method :attachable_content_iiif_url, :content_iiif_url
+  alias_method :attachable_content_image_api_url, :content_image_api_url
   alias_method :attachable_content_info_url, :content_info_url
   alias_method :attachable_content_thumbnail_url, :content_thumbnail_url
 
@@ -61,6 +62,12 @@ class Resource < ApplicationRecord
 
   def content_info_url(page_number = 1)
     return attachable_content_info_url(page_number) if iiif?
+
+    nil
+  end
+
+  def content_image_api_url(page_number, region, size, rotation, quality, format)
+    return attachable_content_image_api_url(page_number, region, size, rotation, quality, format) if iiif?
 
     nil
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,8 +36,10 @@ Rails.application.routes.draw do
         get :thumbnail
       end
     end
-  end
 
+    get 'resources/:id/:region/:size/:rotation/:quality', to: 'resources#image_api', defaults: { format: 'jpg' }
+  end
+  
   # Default route for static front-end
   get '*path', to: "application#fallback_index_html", constraints: -> (request) do
     !request.xhr? && request.format.html?


### PR DESCRIPTION
This pull request adds an additional API endpoint to allow redirecting to the IIIF server Image API endpoint. It looks like most IIIF viewers will treat the `id` attribute in the `service` object as a base URL for a IIIF Image API. So most viewers will append things like `/full/max/0/default.jpg` to the URI in attempt to get an image back. Since we want to use IIIF Cloud to determine which resource to redirect to (source image or PTIF), we've added a route to make that determination, then redirect with the approproate `region`, `size`, `rotation`, `quality` and `format` parameters.

For example, a request to 
```
<iiif-cloud-host>/public/resources/:id/:region/:size/:rotation/:quality
```

Will redirect to
```
<iiif-server-host>/:key/:region/:size/:rotation/:quality
```