### PR TITLE
Include metadata in generated manifests (#90)

### DIFF
--- a/app/jobs/create_manifest_job.rb
+++ b/app/jobs/create_manifest_job.rb
@@ -1,8 +1,8 @@
 class CreateManifestJob < ApplicationJob
-  def perform(resource_id)
+  def perform(resource_id, metadata)
     resource = Resource.find(resource_id)
     return unless resource.iiif?
 
-    resource.update(manifest: Iiif::Manifest.create_for_resource(resource))
+    resource.update(manifest: Iiif::Manifest.create_for_resource(resource, metadata))
   end
 end

--- a/app/jobs/create_manifest_job.rb
+++ b/app/jobs/create_manifest_job.rb
@@ -1,8 +1,8 @@
 class CreateManifestJob < ApplicationJob
-  def perform(resource_id, metadata)
+  def perform(resource_id)
     resource = Resource.find(resource_id)
     return unless resource.iiif?
 
-    resource.update(manifest: Iiif::Manifest.create_for_resource(resource, metadata))
+    resource.update(manifest: Iiif::Manifest.create_for_resource(resource))
   end
 end

--- a/app/services/iiif/manifest.rb
+++ b/app/services/iiif/manifest.rb
@@ -100,6 +100,8 @@ module Iiif
         items: [create_annotation(resource, canvas['id'], page_number)]
       }]
 
+      canvas['metadata'] = resource.metadata
+
       canvas
     end
 

--- a/app/services/iiif/manifest.rb
+++ b/app/services/iiif/manifest.rb
@@ -14,7 +14,7 @@ module Iiif
       JSON.dump(manifest)
     end
 
-    def self.create_for_resource(resource)
+    def self.create_for_resource(resource, metadata)
       manifest = to_json('manifest.json')
       manifest['id'] = "#{base_url(resource)}/manifest"
       manifest['label'] = {
@@ -22,6 +22,9 @@ module Iiif
       }
 
       manifest['items'] = add_resource(resource)
+      if !metadata.nil?
+        manifest['metadata'] = JSON.parse(metadata)
+      end
 
       JSON.dump(manifest)
     end

--- a/app/services/iiif/manifest.rb
+++ b/app/services/iiif/manifest.rb
@@ -14,7 +14,7 @@ module Iiif
       JSON.dump(manifest)
     end
 
-    def self.create_for_resource(resource, metadata)
+    def self.create_for_resource(resource)
       manifest = to_json('manifest.json')
       manifest['id'] = "#{base_url(resource)}/manifest"
       manifest['label'] = {
@@ -22,9 +22,7 @@ module Iiif
       }
 
       manifest['items'] = add_resource(resource)
-      if !metadata.nil?
-        manifest['metadata'] = JSON.parse(metadata)
-      end
+      manifest['metadata'] = resource.metadata
 
       JSON.dump(manifest)
     end

--- a/db/migrate/20250421155502_add_metadata_to_resources.rb
+++ b/db/migrate/20250421155502_add_metadata_to_resources.rb
@@ -1,0 +1,5 @@
+class AddMetadataToResources < ActiveRecord::Migration[7.0]
+  def change
+    add_column :resources, :metadata, :jsonb, default: {}
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_06_12_152246) do
+ActiveRecord::Schema[7.0].define(version: 2025_04_21_155502) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -98,6 +98,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_06_12_152246) do
     t.uuid "uuid", default: -> { "gen_random_uuid()" }
     t.text "manifest"
     t.jsonb "user_defined", default: {}
+    t.jsonb "metadata", default: {}
     t.index ["project_id"], name: "index_resources_on_project_id"
     t.index ["user_defined"], name: "index_resources_on_user_defined", using: :gin
   end


### PR DESCRIPTION
## In this PR

Per #90:
- Allow the transient attribute `:metadata` on the `Resource` model and in allowed params, as passed from `core-data-connector` on `Resource` create and update
- On creating and updating `Resource` instances, include the passed `metadata` param as part of the `CreateManifestJob` and pass along to manifest creation tasks
   - When updating a resource, regenerate manifests. But only if the `metadata` attribute is non-nil, i.e., the update was initiated by a PUT request from `core-data-connector` or other service where the `metadata` param was passed. For now that is the only case where `metadata` will exist on the model.
- Parse the JSON string passed by `core-data-connector` and set it on the manifest as the value for the `"metadata"` key (where it will later be re-serialized into a JSON string), allowing it to be viewed in Clover IIIF viewer

--- 

## Questions

How would we handle this for the `public/presentation/manifest` API endpoint? Since `metadata` is not actually a field on the `Resource` model, it's just a method in `core-data-connector` whose result gets passed as a param, from where I include it in `resource.manifest`—we don't explicitly have access to it outside of that context.
- Should we be storing this as a separate field instead, and including it in the manifest from there rather than as a transient attribute?
- Or should I instead parse and extract it from the generated, individual record manifest and include it on the multi-resource manifest that way?
- Also, presumably the metadata `"label"` fields (i.e. UDF names) are going to be the same for each Resource record, but the `"value"`s are going to be different. How should we combine? (Note that since we are collecting all images as multiple Canvases on a single Manifest, we can only have one `"metadata"` list that applies to all images. We would have to use a Collection for different behavior, I believe.)