### PR TITLE
Order manifest resources by resource_ids (#91)

### DIFF
--- a/app/controllers/public/presentation_controller.rb
+++ b/app/controllers/public/presentation_controller.rb
@@ -21,7 +21,10 @@ module Public
       resources = Resource
                     .preload(Resource.attachment_preloads)
                     .where(uuid: params[:resource_ids])
-                    .order(:name)
+
+      # ensure resources ordered by params[:resource_ids]
+      resources_by_id = resources.index_by(&:uuid)
+      resources = params[:resource_ids].map { |uuid| resources_by_id[uuid] }.compact
 
       json = Iiif::Manifest.create(
         id: params[:id],


### PR DESCRIPTION
Probably could have done this in the last PR 😅 

Per #91:
- Order resources in a `PresentationController`-generated manifest by passed `:resource_ids` param order