### PR TITLE
IIIF #101 - Storage keys

### DIFF
--- a/app/jobs/convert_image_job.rb
+++ b/app/jobs/convert_image_job.rb
@@ -1,4 +1,11 @@
 class ConvertImageJob < ApplicationJob
+
+  CONTENT_TYPE_TIFF = 'image/tiff'
+  FILE_EXTENSION_TIFF = 'tif'
+
+  # In the event the job is started before the file is fully uploaded, we'll retry
+  retry_on ActiveStorage::FileNotFoundError, wait: 10.seconds
+
   def perform(resource_id)
     # Only convert if the passed resource is an image
     resource = Resource.find(resource_id)
@@ -8,24 +15,23 @@ class ConvertImageJob < ApplicationJob
     content = resource.content
     return unless content.attached?
 
-    content.open do |file|
-      begin
-        # Convert the image
-        filepath = Images::Convert.to_tiff(file)
-        filename = Images::Convert.filename(content.filename.to_s, 'tif')
+      content.open do |file|
+        begin
+          # Convert the image
+          filepath = Images::Convert.to_tiff(file)
+          filename = Images::Convert.filename content.filename.to_s, FILE_EXTENSION_TIFF
 
-        # Upload the converted content
-        resource.content_converted.attach(
-          io: File.open(filepath),
-          filename:  filename,
-          content_type: 'image/tiff'
-        )
-
-      rescue MiniMagick::Error => e
-        # Content cannot be converted
-        Rails.logger.error e.message
-        Rails.logger.error e.backtrace.join("\n")
+          # Upload the converted content
+          resource.content_converted.attach(
+            io: File.open(filepath),
+            content_type: CONTENT_TYPE_TIFF,
+            filename:,
+          )
+        rescue MiniMagick::Error => e
+          # Content cannot be converted
+          Rails.logger.error e.message
+          Rails.logger.error e.backtrace.join("\n")
+        end
       end
-    end
   end
 end

--- a/app/jobs/create_manifest_job.rb
+++ b/app/jobs/create_manifest_job.rb
@@ -1,4 +1,8 @@
 class CreateManifestJob < ApplicationJob
+
+  # In the event the job is started before the file is fully uploaded, we'll retry
+  retry_on ActiveStorage::FileNotFoundError, wait: 10.seconds
+
   def perform(resource_id)
     resource = Resource.find(resource_id)
     return unless resource.iiif?

--- a/app/jobs/extract_exif_job.rb
+++ b/app/jobs/extract_exif_job.rb
@@ -1,5 +1,8 @@
 class ExtractExifJob < ApplicationJob
 
+  # In the event the job is started before the file is fully uploaded, we'll retry
+  retry_on ActiveStorage::FileNotFoundError, wait: 10.seconds
+
   def perform(resource_id)
     resource = Resource.find(resource_id)
     return unless resource.content.image?

--- a/app/models/concerns/attachable.rb
+++ b/app/models/concerns/attachable.rb
@@ -9,7 +9,7 @@ module Attachable
 
     # Callbacks
     before_save :delete_attachments
-    before_validation :set_storage_key
+    before_validation :set_attachment_key
 
     def delete_attachments
       self.class.list_attachments&.each do |name|
@@ -22,7 +22,7 @@ module Attachable
       end
     end
 
-    def set_storage_key
+    def set_attachment_key
       # Nothing to set if the attachble object does not implement the :storage_key method
       return unless self.respond_to?(:storage_key)
 

--- a/app/models/concerns/attachable.rb
+++ b/app/models/concerns/attachable.rb
@@ -9,6 +9,7 @@ module Attachable
 
     # Callbacks
     before_save :delete_attachments
+    before_validation :set_storage_key
 
     def delete_attachments
       self.class.list_attachments&.each do |name|
@@ -18,6 +19,21 @@ module Attachable
         return unless attachment.attached?
 
         attachment.purge
+      end
+    end
+
+    def set_storage_key
+      # Nothing to set if the attachble object does not implement the :storage_key method
+      return unless self.respond_to?(:storage_key)
+
+      # Nothing to set of the storage_key is empty
+      return unless self.storage_key.present?
+
+      self.class.list_attachments&.each do |name|
+        attachment = self.send(name)
+        next unless attachment.new_record?
+
+        attachment.key = "#{self.storage_key}/#{ActiveStorage::Blob.generate_unique_secure_token}"
       end
     end
   end
@@ -89,7 +105,7 @@ module Attachable
         attachment = self.send(name)
         return nil unless attachment.attached?
 
-        "#{ENV['IIIF_HOST']}/iiif/3/#{attachment.key}"
+        "#{ENV['IIIF_HOST']}/iiif/3/#{CGI.escape(attachment.key)}"
       end
 
       define_method("#{name}_download_url") do

--- a/app/models/concerns/attachable.rb
+++ b/app/models/concerns/attachable.rb
@@ -9,7 +9,7 @@ module Attachable
 
     # Callbacks
     before_save :delete_attachments
-    before_validation :set_attachment_key
+    before_validation :set_attachment_keys
 
     def delete_attachments
       self.class.list_attachments&.each do |name|
@@ -22,7 +22,7 @@ module Attachable
       end
     end
 
-    def set_attachment_key
+    def set_attachment_keys
       # Nothing to set if the attachble object does not implement the :storage_key method
       return unless self.respond_to?(:storage_key)
 

--- a/app/models/resource.rb
+++ b/app/models/resource.rb
@@ -7,8 +7,11 @@ class Resource < ApplicationRecord
   # Relationships
   belongs_to :project
 
+  # Read only attributes
+  attr_readonly :storage_key
+
   # Resourceable parameters
-  allow_params :project_id, :name, :content, :metadata
+  allow_params :project_id, :name, :content, :metadata, :storage_key
 
   # Callbacks
   before_save :parse_metadata
@@ -52,7 +55,7 @@ class Resource < ApplicationRecord
   def content_base_url
     return attachable_content_base_url unless content_converted.attached?
 
-    "#{ENV['IIIF_HOST_DOCKER'] || ENV['IIIF_HOST']}/iiif/3/#{content_converted.key}"
+    "#{ENV['IIIF_HOST_DOCKER'] || ENV['IIIF_HOST']}/iiif/3/#{CGI.escape(content_converted.key)}"
   end
 
   def content_iiif_url(page_number = 1)

--- a/app/serializers/resources_serializer.rb
+++ b/app/serializers/resources_serializer.rb
@@ -8,7 +8,8 @@ class ResourcesSerializer < BaseSerializer
   index_attributes(:manifest_url) { |resource| manifest_url(resource) }
 
   show_attributes :id, :uuid, :name, :exif, :project_id, :content_url, :content_thumbnail_url, :content_iiif_url,
-                  :content_preview_url, :content_download_url, :content_inline_url, :manifest, :content_type
+                  :content_preview_url, :content_download_url, :content_inline_url, :manifest, :content_type,
+                  :storage_key
 
   show_attributes(:manifest_url) { |resource| manifest_url(resource) }
 

--- a/client/src/components/AttachmentDetails.js
+++ b/client/src/components/AttachmentDetails.js
@@ -29,10 +29,12 @@ const AttachmentDetails: ComponentType<any> = (props: Props) => {
       )}
       { props.attachment && (
         <List
-          className={cx(styles.ui, styles.list, styles.horizontal)}
-          horizontal
+          className={cx(styles.ui, styles.list)}
+          padded='very'
+          relaxed='very'
         >
           <List.Item
+            className={styles.item}
             content={props.attachment?.key}
             header={t('AttachmentDetails.labels.key')}
             image={(

--- a/client/src/components/AttachmentDetails.module.css
+++ b/client/src/components/AttachmentDetails.module.css
@@ -2,8 +2,7 @@
   margin-top: 1.5em;
 }
 
-.attachmentDetails > .ui.list.horizontal {
+.attachmentDetails > .ui.list > .item {
   display: flex;
-  justify-content: space-between;
-  width: 100%;
+  align-items: center;
 }

--- a/client/src/i18n/en.json
+++ b/client/src/i18n/en.json
@@ -130,7 +130,9 @@
       "attachments": "Attachments",
       "content": "Content",
       "convertedImage": "Converted PTIF",
+      "name": "Name",
       "sourceImage": "Source Image",
+      "storageKey": "Storage key",
       "uuid": "Unique identifier"
     },
     "messages": {

--- a/client/src/pages/Resource.js
+++ b/client/src/pages/Resource.js
@@ -167,7 +167,7 @@ const ResourceForm = (props: Props) => {
         </Form.Input>
         <Form.Input
           error={props.isError('name')}
-          label={t('Project.labels.name')}
+          label={t('Resource.labels.name')}
           onChange={props.onTextInputChange.bind(this, 'name')}
           required={props.isRequired('name')}
           value={props.item.name || ''}

--- a/client/src/types/Resource.js
+++ b/client/src/types/Resource.js
@@ -22,5 +22,6 @@ export type Resource = {
   project_id: number,
   project: Project,
   content_info: AttachmentInfo,
-  content_converted_info: AttachmentInfo
+  content_converted_info: AttachmentInfo,
+  storage_key: string
 };

--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -42,6 +42,11 @@ export default defineConfig(({ mode }) => {
           changeOrigin: true,
           secure: false
         },
+        '/rails/active_storage': {
+          target: env.VITE_PROXY_URL,
+          changeOrigin: true,
+          secure: false
+        },
         '/sidekiq': {
           target: env.VITE_PROXY_URL,
           changeOrigin: true,

--- a/db/migrate/20250723194140_add_storage_key_to_resources.rb
+++ b/db/migrate/20250723194140_add_storage_key_to_resources.rb
@@ -1,0 +1,5 @@
+class AddStorageKeyToResources < ActiveRecord::Migration[8.0]
+  def change
+    add_column :resources, :storage_key, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_07_22_100261) do
+ActiveRecord::Schema[8.0].define(version: 2025_07_23_194140) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pgcrypto"
@@ -99,6 +99,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_07_22_100261) do
     t.text "manifest"
     t.jsonb "user_defined", default: {}
     t.jsonb "metadata", default: {}
+    t.string "storage_key"
     t.index ["project_id"], name: "index_resources_on_project_id"
     t.index ["user_defined"], name: "index_resources_on_user_defined", using: :gin
   end


### PR DESCRIPTION
This pull request implements the ability for a `resource` record to contain a `storage_key`, which will serve as the object prefix (e.g. in an S3 bucket) to allowing grouping of resources under a logical folder.

Note: This feature will not be used directly within IIIF Cloud, but instead by applications that use IIIF Cloud for media storage via `triple_eye_effable`.

This pull request also refactors the `AttachmentDetails` component to allow for longer object keys.

<img width="1053" height="857" alt="Screenshot 2025-07-24 at 3 08 02 PM" src="https://github.com/user-attachments/assets/9247f2d2-396a-4c69-8f2f-1ad4724c7ef0" />

Finally, this pull request fixes an issue where a race condition was occurring in the time it was taking to fully upload the file to the storage service, and the background workers downloading the file for processing. According to the Rails [documentation](https://guides.rubyonrails.org/active_storage_overview.html#downloading-files), this should be an issue when using the `after_create_commit` callback, but I was still seeing the problem.

> It's important to know that the file is not yet available in the after_create callback but in the after_create_commit only.