### PR TITLE
IIIF #104 - File Not Found

### DIFF
--- a/app/jobs/convert_image_job.rb
+++ b/app/jobs/convert_image_job.rb
@@ -4,7 +4,7 @@ class ConvertImageJob < ApplicationJob
   FILE_EXTENSION_TIFF = 'tif'
 
   # In the event the job is started before the file is fully uploaded, we'll retry
-  retry_on ActiveStorage::FileNotFoundError, wait: 10.seconds
+  retry_on Exceptions::FileNotUploadedError, wait: 10.seconds
 
   def perform(resource_id)
     # Only convert if the passed resource is an image
@@ -15,23 +15,25 @@ class ConvertImageJob < ApplicationJob
     content = resource.content
     return unless content.attached?
 
-      content.open do |file|
-        begin
-          # Convert the image
-          filepath = Images::Convert.to_tiff(file)
-          filename = Images::Convert.filename content.filename.to_s, FILE_EXTENSION_TIFF
+    raise Exceptions::FileNotUploadedError unless resource.content_uploaded?
 
-          # Upload the converted content
-          resource.content_converted.attach(
-            io: File.open(filepath),
-            content_type: CONTENT_TYPE_TIFF,
-            filename:,
-          )
-        rescue MiniMagick::Error => e
-          # Content cannot be converted
-          Rails.logger.error e.message
-          Rails.logger.error e.backtrace.join("\n")
-        end
+    content.open do |file|
+      begin
+        # Convert the image
+        filepath = Images::Convert.to_tiff(file)
+        filename = Images::Convert.filename content.filename.to_s, FILE_EXTENSION_TIFF
+
+        # Upload the converted content
+        resource.content_converted.attach(
+          io: File.open(filepath),
+          content_type: CONTENT_TYPE_TIFF,
+          filename:,
+        )
+      rescue MiniMagick::Error => e
+        # Content cannot be converted
+        Rails.logger.error e.message
+        Rails.logger.error e.backtrace.join("\n")
       end
+    end
   end
 end

--- a/app/jobs/create_manifest_job.rb
+++ b/app/jobs/create_manifest_job.rb
@@ -1,11 +1,13 @@
 class CreateManifestJob < ApplicationJob
 
   # In the event the job is started before the file is fully uploaded, we'll retry
-  retry_on ActiveStorage::FileNotFoundError, wait: 10.seconds
+  retry_on Exceptions::FileNotUploadedError, wait: 10.seconds
 
   def perform(resource_id)
     resource = Resource.find(resource_id)
     return unless resource.iiif?
+
+    raise Exceptions::FileNotUploadedError unless resource.content_uploaded?
 
     resource.update(manifest: Iiif::Manifest.create_for_resource(resource))
   end

--- a/app/jobs/extract_exif_job.rb
+++ b/app/jobs/extract_exif_job.rb
@@ -1,11 +1,13 @@
 class ExtractExifJob < ApplicationJob
 
   # In the event the job is started before the file is fully uploaded, we'll retry
-  retry_on ActiveStorage::FileNotFoundError, wait: 10.seconds
+  retry_on Exceptions::FileNotUploadedError, wait: 10.seconds
 
   def perform(resource_id)
     resource = Resource.find(resource_id)
     return unless resource.content.image?
+
+    raise Exceptions::FileNotUploadedError unless resource.content_uploaded?
 
     exif = nil
 

--- a/app/models/concerns/attachable.rb
+++ b/app/models/concerns/attachable.rb
@@ -148,6 +148,13 @@ module Attachable
 
         "#{self.send("#{name}_base_url")}/square/^!250,250/0/default.jpg"
       end
+
+      define_method("#{name}_uploaded?") do
+        attachment = self.send(name)
+        return false unless attachment.attached?
+
+        ActiveStorage::Blob.service.exist?(attachment.key)
+      end
     end
 
     def attachment_preloads

--- a/config/application.rb
+++ b/config/application.rb
@@ -23,5 +23,7 @@ module IiifCloud
     # Middleware like session, flash, cookies can be added back manually.
     # Skip views, helpers and assets when generating a new resource.
     config.api_only = true
+
+    config.autoload_lib(ignore: %w[tasks assets iiif])
   end
 end

--- a/lib/exceptions.rb
+++ b/lib/exceptions.rb
@@ -1,0 +1,3 @@
+module Exceptions
+  class FileNotUploadedError < StandardError; end
+end


### PR DESCRIPTION
This pull request fixes an issue with the ActiveStorage flow, where the callback on the model is fired before the file is fully uploaded to the storage backend. Within the callback, we're queuing a job that downloads the file, which fails when not fully uploaded.

The solution was to add a `content_uploaded?` method which will check the storage backend to see if the object with the passed key exists. We'll use this method in the job to check if the file is ready for download. If not, we'll retry the job in another 10 seconds.