### PR TITLE
IIIF #103 - Update content

### DIFF
--- a/app/controllers/api/resources_controller.rb
+++ b/app/controllers/api/resources_controller.rb
@@ -57,6 +57,14 @@ class Api::ResourcesController < Api::BaseController
     Resource.where(subquery.arel.exists)
   end
 
+  def permitted_params(item = nil)
+    p_params = super
+
+    p_params -= [:storage_key] if action_name == 'update'
+
+    p_params
+  end
+
   private
 
   def can_clear_cache?


### PR DESCRIPTION
This pull request fixes an issue with updating resources from consuming applications. Using the `triple_eye_effable` gem, the `storage_key` property is always sent, but it is a read-only property that cannot be changed once set.

The solution was to remove the `storage_key` attribute from the set of permitted parameters on the `update` action.