### PR TITLE
Archnet #1549 - Direct uploads

### DIFF
--- a/app/models/concerns/attachable.rb
+++ b/app/models/concerns/attachable.rb
@@ -31,7 +31,12 @@ module Attachable
 
       self.class.list_attachments&.each do |name|
         attachment = self.send(name)
+
+        # Only set the storage key for a new record
         next unless attachment.new_record?
+
+        # If the "storage_key" attribute is set on the metadata, this blob was created as a direct upload
+        next if attachment.metadata && attachment.metadata[:storage_key].present?
 
         attachment.key = "#{self.storage_key}/#{ActiveStorage::Blob.generate_unique_secure_token}"
       end

--- a/config/initializers/active_storage.rb
+++ b/config/initializers/active_storage.rb
@@ -1,6 +1,23 @@
 require_relative '../../app/controllers/concerns/public/authenticateable'
 
 Rails.application.config.to_prepare do
+  # Custom storage key generation based on the "storage_key" attribute in metadata
+  ActiveStorage::Blob.class_eval do
+    def key
+      self[:key] ||= generate_key
+    end
+
+    private
+
+    def generate_key
+      object_prefix = self.metadata[:storage_key]
+      object_key = self.class.generate_unique_secure_token(length: self.class::MINIMUM_TOKEN_LENGTH)
+
+      [object_prefix, object_key].compact.join('/')
+    end
+  end
+
+  # Authentication for direct uploads
   ActiveStorage::DirectUploadsController.class_eval do
     # Includes
     include Public::Authenticateable

--- a/config/initializers/active_storage.rb
+++ b/config/initializers/active_storage.rb
@@ -1,0 +1,11 @@
+require_relative '../../app/controllers/concerns/public/authenticateable'
+
+Rails.application.config.to_prepare do
+  ActiveStorage::DirectUploadsController.class_eval do
+    # Includes
+    include Public::Authenticateable
+
+    # Actions
+    before_action :authenticate_request
+  end
+end

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -14,4 +14,9 @@ Rails.application.config.middleware.insert_before 0, Rack::Cors do
     resource '/public/resources/:id/info*', headers: :any, methods: :get
     resource '*/rails/active_storage/blobs/redirect/*', headers: :any, methods: :get
   end
+
+  allow do
+    origins '*'
+    resource '*/rails/active_storage/direct_uploads', headers: :any, methods: [:options, :post, :put]
+  end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -13,6 +13,7 @@
 ActiveRecord::Schema[8.0].define(version: 2025_07_23_194140) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
+  enable_extension "pg_stat_statements"
   enable_extension "pgcrypto"
 
   create_table "active_storage_attachments", force: :cascade do |t|


### PR DESCRIPTION
This pull request makes the following changes to support direct uploads:

- Updates the `attachable` concern to only set the attachment key if the `storage_key` key is not present in the `metadata` attribute. ActiveStorage does not provide a way to set custom keys for direct uploads, so we're using the `metadata` attribute to store the storage key and set it as the key. See [/initializer/active_storage.rb](https://github.com/performant-software/iiif-cloud/compare/develop...feature/archnet1549_direct_uploads#diff-31b378f6c9c59bbc88d48d39cf13fa889ec3fa879a491b53bf8757cbbb26b9d9)
- Adds authentication to the `ActiveStorage::DirectUploadsController`