### PR TITLE
IIIF #107 - Image API

### DIFF
--- a/app/controllers/public/resources_controller.rb
+++ b/app/controllers/public/resources_controller.rb
@@ -33,16 +33,14 @@ class Public::ResourcesController < Api::ResourcesController
     page_number = params[:page] || 1
 
     redirect_resource do |resource|
-      if resource.image?
-        resource.content_converted_image_api_url(
-          page_number,
-          params[:region],
-          params[:size],
-          params[:rotation],
-          params[:quality],
-          params[:format]
-        )
-      end
+      resource.content_image_api_url(
+        page_number,
+        params[:region],
+        params[:size],
+        params[:rotation],
+        params[:quality],
+        params[:format]
+      )
     end
   end
 


### PR DESCRIPTION
This pull request fixes a bug with the `/public/resources/:id/:region/:size/:rotation/:quality` API endpoint, where it was returning a 404 for PDF and video files.

The issue was that we were only allowing the route to be used for image files and using the `content_converted_image_api_url`, because PDFs and videos do not have converted content. But for PDFs and videos, the IIIF server should be able to generate thumbnails for the source files.