### PR TITLE
IIIF #110 - Object prefixes

### DIFF
--- a/config/initializers/active_storage.rb
+++ b/config/initializers/active_storage.rb
@@ -13,7 +13,7 @@ Rails.application.config.to_prepare do
       object_prefix = self.metadata[:storage_key]
       object_key = self.class.generate_unique_secure_token(length: self.class::MINIMUM_TOKEN_LENGTH)
 
-      [object_prefix, object_key].compact.join('/')
+      [object_prefix, object_key].reject(&:blank?).join('/')
     end
   end
 


### PR DESCRIPTION
This pull request updates the custom object prefix generation to exclude empty string and `nil` values. Previously we were using the `compact` method, which will only remove `nil` values. This was resulting in objects being nested under a `/` prefix (e.g. `/abcdefg` instead of `abcdefg`) if the `metadata.storage_key` value was empty.