### PR TITLE
Update profile field in image service

### DIFF
--- a/app/services/iiif/manifest.rb
+++ b/app/services/iiif/manifest.rb
@@ -76,7 +76,7 @@ module Iiif
         annotation['body']['service'] = [{
           id: "#{base_url(resource)};#{page_number}",
           type: 'ImageService3',
-          profile: 'http://iiif.io/api/image/3/level2.json'
+          profile: 'level2'
         }]
       end
 


### PR DESCRIPTION
### In this PR
Address an issue with manifest validation in Recogito Studio by updating the `profile` field of the image service to be one of the values expected by the `@allmaps/iiif-parser` parser (see [here](https://github.com/allmaps/allmaps/blob/3d43ed43e247c152992d628b3d05fb9dc4c15bef/packages/iiif-parser/src/schemas/image-service.3.ts#L6)).