### PR TITLE
User-initiated manifest generation, metadata from UDFs

### DIFF
--- a/app/controllers/api/resources_controller.rb
+++ b/app/controllers/api/resources_controller.rb
@@ -13,7 +13,7 @@ class Api::ResourcesController < Api::BaseController
   # Actions
   before_action :set_defineable_params, only: :index
   before_action :validate_new_resource, unless: -> { current_user.admin? }, only: :create
-  before_action :validate_resource, unless: -> { current_user.admin? }, only: [:update, :destroy]
+  before_action :validate_resource, unless: -> { current_user.admin? }, only: [:update, :destroy, :create_manifest]
   before_action :validate_resources, unless: -> { current_user.admin? }, only: :index
 
   def clear_cache
@@ -37,6 +37,13 @@ class Api::ResourcesController < Api::BaseController
 
     resource = Resource.find(params[:id])
     ConvertImageJob.perform_later(resource.id)
+
+    render json: {}, status: :ok
+  end
+
+  def create_manifest
+    resource = Resource.find(params[:id])
+    CreateManifestJob.perform_later(resource.id)
 
     render json: {}, status: :ok
   end

--- a/app/models/resource.rb
+++ b/app/models/resource.rb
@@ -127,8 +127,8 @@ class Resource < ApplicationRecord
   end
 
   def after_update
-    if saved_change_to_metadata?
-      # Recreate the manifest if metadata updated
+    if saved_change_to_metadata? || saved_change_to_user_defined?
+      # Recreate the manifest if the metadata or user-defined field values were updated
       CreateManifestJob.perform_later(self.id)
     end
 

--- a/app/serializers/resources_serializer.rb
+++ b/app/serializers/resources_serializer.rb
@@ -9,7 +9,7 @@ class ResourcesSerializer < BaseSerializer
 
   show_attributes :id, :uuid, :name, :exif, :project_id, :content_url, :content_thumbnail_url, :content_iiif_url,
                   :content_preview_url, :content_download_url, :content_inline_url, :manifest, :content_type,
-                  :storage_key
+                  :storage_key, :metadata
 
   show_attributes(:manifest_url) { |resource| manifest_url(resource) }
 

--- a/app/services/iiif/manifest.rb
+++ b/app/services/iiif/manifest.rb
@@ -8,7 +8,7 @@ module Iiif
       }
 
       resources.each do |resource|
-        manifest['items'] += add_resource(resource)
+        manifest['items'] += add_resource(resource, canvas_metadata: true)
       end
 
       JSON.dump(manifest)
@@ -21,15 +21,17 @@ module Iiif
         en: [resource.name]
       }
 
-      manifest['items'] = add_resource(resource)
-      manifest['metadata'] = resource.metadata
+      manifest['items'] = add_resource(resource, canvas_metadata: false)
+
+      metadata = resource_metadata(resource)
+      manifest['metadata'] = metadata if metadata.present?
 
       JSON.dump(manifest)
     end
 
     private
 
-    def self.add_resource(resource)
+    def self.add_resource(resource, canvas_metadata: false)
       items = []
 
       info = resource_info(resource)
@@ -37,9 +39,10 @@ module Iiif
       page_count = info['page_count'] || 1
       width = info['width']
       height = info['height']
+      metadata = canvas_metadata ? resource_metadata(resource) : nil
 
       page_count.times do |index|
-        items << create_canvas(resource, width, height, index + 1)
+        items << create_canvas(resource, width, height, index + 1, metadata)
       end
 
       items
@@ -83,7 +86,7 @@ module Iiif
       annotation
     end
 
-    def self.create_canvas(resource, width, height, page_number)
+    def self.create_canvas(resource, width, height, page_number, metadata = nil)
       canvas = to_json('canvas.json')
       canvas['id'] = "#{base_url(resource)}/canvas/#{page_number}"
       canvas['width'] = width
@@ -100,9 +103,47 @@ module Iiif
         items: [create_annotation(resource, canvas['id'], page_number)]
       }]
 
-      canvas['metadata'] = resource.metadata
+      canvas['metadata'] = metadata if metadata.present?
 
       canvas
+    end
+
+    def self.resource_metadata(resource)
+      # use UDFs to build metadata JSON
+      return [] unless resource.respond_to?(:user_defined)
+
+      build_metadata(user_defined_fields(resource), resource.user_defined || {})
+    end
+
+    def self.user_defined_fields(resource)
+      # get UDFs from resource type + project
+      query = UserDefinedFields::UserDefinedField.where(table_name: resource.class.to_s)
+
+      project = resource.class.respond_to?(:resolve_defineable) && resource.class.resolve_defineable&.call(resource)
+
+      if project
+        query = query.where(defineable_id: project.id, defineable_type: project.class.to_s)
+      end
+
+      query.order(:order)
+    end
+
+    def self.build_metadata(fields, user_defined)
+      # build IIIF Presentation v3 Manifest metadata array
+      fields.filter_map do |field|
+        value = user_defined[field.uuid]
+
+        values = Array.wrap(value)
+                   .map { |v| v.to_s }
+                   .reject(&:blank?)
+
+        next if values.empty?
+
+        {
+          label: { en: [field.column_name] },
+          value: { en: values }
+        }
+      end
     end
 
     def self.resource_info(resource)

--- a/app/services/iiif/manifest.rb
+++ b/app/services/iiif/manifest.rb
@@ -109,10 +109,46 @@ module Iiif
     end
 
     def self.resource_metadata(resource)
-      # use UDFs to build metadata JSON
+      # use UDFs + metadata column to build metadata JSON
+      udf_metadata(resource) + column_metadata(resource)
+    end
+
+    def self.udf_metadata(resource)
       return [] unless resource.respond_to?(:user_defined)
 
       build_metadata(user_defined_fields(resource), resource.user_defined || {})
+    end
+
+    def self.column_metadata(resource)
+      return [] unless resource.respond_to?(:metadata)
+
+      metadata = resource.metadata
+      return [] unless metadata.is_a?(Array)
+
+      metadata.filter_map { |entry| normalize_metadatum(entry) }
+    end
+
+    def self.normalize_metadatum(entry)
+      # ignore bare strings with no label/value pair, nil, etc
+      return nil unless entry.is_a?(Hash)
+
+      # assume hashes are already correct
+      return entry if entry['label'].is_a?(Hash) && entry['value'].is_a?(Hash)
+
+      # must have both label and value
+      label = entry.key?('label') ? entry['label'] : entry[:label]
+      return nil if label.blank?
+
+      # ensure value exists and is/becomes a non-empty array
+      value = entry.key?('value') ? entry['value'] : entry[:value]
+      values = Array.wrap(value).map { |v| v.to_s }.reject(&:blank?)
+      return nil if values.empty?
+
+      # normalize to iiif presentation v3 like { label: { lang: value } }
+      {
+        label: { en: [label.to_s] },
+        value: { en: values }
+      }
     end
 
     def self.user_defined_fields(resource)

--- a/client/src/i18n/en.json
+++ b/client/src/i18n/en.json
@@ -135,6 +135,7 @@
       "name": "Name",
       "sourceImage": "Source Image",
       "storageKey": "Storage key",
+      "externalMetadata": "External Metadata",
       "uuid": "Unique identifier"
     },
     "messages": {
@@ -149,6 +150,9 @@
       "manifest": {
         "content": "A request to rebuild the IIIF manifest has been submitted. It may take a moment to process.",
         "header": "Rebuild Manifest"
+      },
+      "externalMetadata": {
+        "content": "This metadata is synced from an external source, such as FairData, and can't be edited here. To change these values, edit them in the source system."
       }
     }
   },

--- a/client/src/i18n/en.json
+++ b/client/src/i18n/en.json
@@ -124,7 +124,9 @@
     "buttons": {
       "clearCache": "Clear cache",
       "convert": "Convert",
-      "exif": "View Info"
+      "exif": "View Info",
+      "rebuildManifest": "Rebuild manifest",
+      "viewManifest": "View manifest"
     },
     "labels": {
       "attachments": "Attachments",
@@ -143,6 +145,10 @@
       "convert": {
         "content": "A request to convert the resource to a PTIF has been submitted. Please refresh the page to view the results.",
         "header": "Convert Resource"
+      },
+      "manifest": {
+        "content": "A request to rebuild the IIIF manifest has been submitted. It may take a moment to process.",
+        "header": "Rebuild Manifest"
       }
     }
   },

--- a/client/src/pages/Resource.js
+++ b/client/src/pages/Resource.js
@@ -47,6 +47,7 @@ const ResourceForm = (props: Props) => {
   const [converted, setConverted] = useState(false);
   const [errors, setErrors] = useState([]);
   const [info, setInfo] = useState(false);
+  const [manifestRebuilt, setManifestRebuilt] = useState(false);
   const [project, setProject] = useState();
   const [tab, setTab] = useState(Tabs.content);
 
@@ -103,6 +104,18 @@ const ResourceForm = (props: Props) => {
     ResourcesService
       .convert(props.item.id)
       .then(() => setConverted(true))
+      .catch(({ response: { data } }) => setErrors(data.errors))
+  ), [props.item.id]);
+
+  /**
+   * Calls the `/api/resources/:id/create_manifest API endpoint and sets any errors on the state.
+   *
+   * @type {function(): Promise<*>}
+   */
+  const onCreateManifest = useCallback(() => (
+    ResourcesService
+      .createManifest(props.item.id)
+      .then(() => setManifestRebuilt(true))
       .catch(({ response: { data } }) => setErrors(data.errors))
   ), [props.item.id]);
 
@@ -181,6 +194,40 @@ const ResourceForm = (props: Props) => {
           onClearValidationError={props.onClearValidationError}
           tableName='Resource'
         />
+        <Form.Field>
+          <Button
+            basic
+            content={t('Resource.buttons.rebuildManifest')}
+            icon='refresh'
+            onClick={onCreateManifest}
+            type='button'
+          />
+          { props.item.manifest && (
+            <Button
+              as='a'
+              basic
+              content={t('Resource.buttons.viewManifest')}
+              href={props.item.manifest_url}
+              icon='file code outline'
+              rel='noopener noreferrer'
+              target='_blank'
+              type='button'
+            />
+          )}
+        </Form.Field>
+        { manifestRebuilt && (
+          <Toaster
+            onDismiss={() => setManifestRebuilt(false)}
+            type={Toaster.MessageTypes.info}
+          >
+            <Message.Header
+              content={t('Resource.messages.manifest.header')}
+            />
+            <Message.Content
+              content={t('Resource.messages.manifest.content')}
+            />
+          </Toaster>
+        )}
         { info && exif && (
           <ResourceExifModal
             exif={exif}

--- a/client/src/pages/Resource.js
+++ b/client/src/pages/Resource.js
@@ -324,6 +324,29 @@ const ResourceForm = (props: Props) => {
           )}
         </Segment>
       </SimpleEditPage.Tab>
+      { props.item.metadata && props.item.metadata.length > 0 && (
+        <SimpleEditPage.Tab
+          key='external'
+          name={t('Resource.labels.externalMetadata')}
+        >
+          <Message
+            content={t('Resource.messages.externalMetadata.content')}
+            info
+          />
+          { props.item.metadata
+            .filter((entry) => entry
+              && entry.value !== null
+              && entry.value !== undefined
+              && entry.value !== '')
+            .map((entry, index) => (
+              <ReadOnlyField
+                key={index}
+                label={typeof entry.label === 'string' ? entry.label : JSON.stringify(entry.label)}
+                value={String(entry.value)}
+              />
+            ))}
+        </SimpleEditPage.Tab>
+      )}
     </SimpleEditPage>
   );
 };

--- a/client/src/services/Resources.js
+++ b/client/src/services/Resources.js
@@ -32,6 +32,17 @@ class Resources extends BaseService {
   }
 
   /**
+   * Calls the `/api/resources/:id/create_manifest` API endpoint.
+   *
+   * @param id
+   *
+   * @returns {*}
+   */
+  createManifest(id: number): Promise<any> {
+    return this.getAxios().post(`${this.getBaseUrl()}/${id}/create_manifest`, {}, this.getConfig());
+  }
+
+  /**
    * Returns the resources base URL.
    *
    * @returns {string}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,6 +24,7 @@ Rails.application.routes.draw do
     resources :resources do
       post :clear_cache, on: :member
       post :convert, on: :member
+      post :create_manifest, on: :member
       post :upload, on: :collection
     end
     resources :users


### PR DESCRIPTION
### In this PR

- Allow user to directly queue manifest regeneration, and view a manifest, with buttons
- Include FairImage UDFs in generated manifest (merge with FairData-sourced metadata column)
- Auto-regenerate manifests when FairImage UDFs change
- Add a new tab for "external metadata" to make FairData-sourced metadata visible to user
- Fix invalid IIIF presentation v3 label/value pairs

### Notes

- Includes a breaking change where metadata labels/values are correctly language scoped, which will need to be dealt with in just [this one FDS line](https://github.com/performant-software/core-data-places/blob/48a160aa26564496634211865f45f70cb5c26ed3/src/apps/gallery/ManifestGrid.tsx#L32).