### PR TITLE
Config updates to avoid OOM errors that crash the server

### DIFF
--- a/lib/iiif/cantaloupe.properties
+++ b/lib/iiif/cantaloupe.properties
@@ -32,7 +32,7 @@ https.key_password = password
 # !! Constrains the size of the web server's thread pool. Leave blank to
 # use the defaults.
 http.min_threads =
-http.max_threads =
+http.max_threads = 24
 
 # !! Maximum size of the request queue. Leave blank to use the default.
 http.accept_queue_limit =
@@ -439,7 +439,7 @@ GrokProcessor.path_to_binaries =
 # The following will enable disk to be used as well as memory during
 # PDF loading in PdfBoxProcessor.  If `max_memory_bytes` is -1 it
 # will use unlimited memory.
-processor.pdf.scratch_file_enabled = false
+processor.pdf.scratch_file_enabled = true
 processor.pdf.max_memory_bytes = -1
 
 ###########################################################################

--- a/lib/iiif/start.sh
+++ b/lib/iiif/start.sh
@@ -1,1 +1,1 @@
-java -Dcantaloupe.config=/root/cantaloupe-5.0.5/cantaloupe.properties -Xmx6g -jar /root/cantaloupe-5.0.5/cantaloupe-5.0.5.jar
+java -Dcantaloupe.config=/root/cantaloupe-5.0.5/cantaloupe.properties -Xmx6g -XX:+ExitOnOutOfMemoryError -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/root/ -jar /root/cantaloupe-5.0.5/cantaloupe-5.0.5.jar


### PR DESCRIPTION
### In this PR
Applies some minor config updates (suggested by Claude) in the hope of avoiding the cantaloupe server crashing when multiple large PDF pages are fetched simultaneously. The updates do three things:
- Update `start.sh` so that the server will exit (and thus automatically restart) on a javascript OOM error;
- Add `http.max_threads = 24` to throttle concurrency so that the heap isn't overloaded when many requests are made at once;
- Change `processor.pdf.scratch_file_enabled` to `true`, which changes how PDFBox handles large PDFs, preventing it from buffering the entire file to the heap while rendering.

Note that these changes have already been applied on the Cantaloupe servers via the DO web consoles; this PR brings the codebase up to date with those changes.