### PR TITLE
Add `duration` to audio and video manifests

### DIFF
--- a/app/services/iiif/manifest.rb
+++ b/app/services/iiif/manifest.rb
@@ -34,11 +34,17 @@ module Iiif
     def self.add_resource(resource, canvas_metadata: false)
       items = []
 
-      info = resource_info(resource)
-
-      page_count = info['page_count'] || 1
-      height = info['height']
-      width = info['width']
+      if resource.image? || resource.pdf?
+        info = resource_info(resource)
+        page_count = info['page_count'] || 1
+        height = info['height']
+        width = info['width']
+      else
+        page_count = 1
+        height = resource.content&.blob&.metadata[:height]
+        width = resource.content&.blob&.metadata[:width]
+      end
+      
       metadata = canvas_metadata ? resource_metadata(resource) : nil
 
       page_count.times do |index|

--- a/app/services/iiif/manifest.rb
+++ b/app/services/iiif/manifest.rb
@@ -52,7 +52,7 @@ module Iiif
       "#{ENV['HOSTNAME']}/public/resources/#{resource.uuid}"
     end
 
-    def self.create_annotation(resource, target, page_number)
+    def self.create_annotation(resource, target, page_number, width, height)
       annotation = to_json('annotation.json')
       annotation['id'] = "#{base_url(resource)}/canvas/#{page_number}/page/1/annotation/1"
       annotation['target'] = target
@@ -71,11 +71,9 @@ module Iiif
         type = 'Sound'
       end
 
-      info = resource_info(resource)
-
       if resource.image? || resource.pdf? || resource.video?
-        annotation['body']['height'] = info['height']
-        annotation['body']['width'] = info['width']
+        annotation['body']['height'] = height
+        annotation['body']['width'] = width
       end
 
       if resource.audio? || resource.video?
@@ -112,7 +110,7 @@ module Iiif
       canvas['items'] = [{
         id: "#{base_url(resource)}/canvas/#{page_number}/page/1",
         type: 'AnnotationPage',
-        items: [create_annotation(resource, canvas['id'], page_number)]
+        items: [create_annotation(resource, canvas['id'], page_number, width, height)]
       }]
 
       canvas['metadata'] = metadata if metadata.present?

--- a/app/services/iiif/manifest.rb
+++ b/app/services/iiif/manifest.rb
@@ -37,8 +37,8 @@ module Iiif
       info = resource_info(resource)
 
       page_count = info['page_count'] || 1
-      width = info['width']
       height = info['height']
+      width = info['width']
       metadata = canvas_metadata ? resource_metadata(resource) : nil
 
       page_count.times do |index|
@@ -71,6 +71,17 @@ module Iiif
         type = 'Sound'
       end
 
+      info = resource_info(resource)
+
+      if resource.image? || resource.pdf? || resource.video?
+        annotation['body']['height'] = info['height']
+        annotation['body']['width'] = info['width']
+      end
+
+      if resource.audio? || resource.video?
+        annotation['body']['duration'] = resource.content&.blob&.metadata[:duration]
+      end
+
       annotation['body']['id'] = id
       annotation['body']['type'] = type
       annotation['body']['format'] = resource.content_type
@@ -89,8 +100,9 @@ module Iiif
     def self.create_canvas(resource, width, height, page_number, metadata = nil)
       canvas = to_json('canvas.json')
       canvas['id'] = "#{base_url(resource)}/canvas/#{page_number}"
-      canvas['width'] = width
-      canvas['height'] = height
+      canvas['height'] = height if height
+      canvas['width'] = width if width
+      canvas['duration'] = resource.content&.blob&.metadata[:duration] if (resource.video? || resource.audio?)
       canvas['label'] = {
         en: [
           resource.name


### PR DESCRIPTION
### In this PR
Updates the manifest generation functions to add in a `duration` field for audio and video media. Also adds the width and height to the annotation body for images, to match the simple image manifest [recipe](https://iiif.io/api/cookbook/recipe/0001-mvm-image/).

### Notes
- I tested this locally with video, audio, and image, and the duration was correctly added. I have not yet done any really robust stress testing of weird corner cases where the duration is null in the metadata, although I tried to write it so that in that case it would just have a null duration.
- The specification requires that the duration be a floating point number; in the examples I tested this was always the case, but possibly the type should be coerced somehow. (E.g. if the duration is exactly 120, it should be entered into the manifest as 120.0.)
- Note that despite the lack of duration data in the manifest, I had no trouble playing audio and video, both in the FairImage UI and by putting the manifest URL into online viewers. Still, it's probably good form to include it when possible.